### PR TITLE
Add autocomplete support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ put it somewhere in your PATH, or you can clone it everywhere
 you want to create a multigit project in, and call it as `./mgit`
 (or `mgit` on Windows).
 
+If you would also like to use the optional autocomplete script which
+lists available `mgit` and `git` commands and repos, source the `mgit-autocomplete.sh`
+script from your `.bash_profile`.
+
 ## How do I use it?
 
 Let's see a bare bones example:

--- a/mgit
+++ b/mgit
@@ -24,7 +24,7 @@ usage() {
 	echo "   ls-untracked                 list files untracked by any repo"
 	echo "   ls-double-tracked            list files tracked by multiple repos"
 	echo "   ls-tracked                   list files and which repos are tracking them"
-	echo "   which [FILENAME]             list which repo(s) are tracking a file"
+	echo "   which FILENAME               list which repo(s) are tracking a file"
 	echo
 	echo "   init REPO                              create a local repo"
 	echo "   clone [REMOTE/]REPO|URL[=VERSION] ...  clone one ore more repos"
@@ -107,6 +107,7 @@ tracked_files() {
 }
 
 which_tracks() {
+	[ -z "$1" ] && echo "Please provide a filename" && return
 	local path="$(readlink -f $PWD0/$1)"
 	path="${path#$PWD/}" #get path relative to root for matching
 	list_tracked | grep "$path" | awk '{print $1}'

--- a/mgit
+++ b/mgit
@@ -24,6 +24,7 @@ usage() {
 	echo "   ls-untracked                 list files untracked by any repo"
 	echo "   ls-double-tracked            list files tracked by multiple repos"
 	echo "   ls-tracked                   list files and which repos are tracking them"
+	echo "   which [FILENAME]             list which repo(s) are tracking a file"
 	echo
 	echo "   init REPO                              create a local repo"
 	echo "   clone [REMOTE/]REPO|URL[=VERSION] ...  clone one ore more repos"
@@ -103,6 +104,12 @@ tracked_files() {
 	for repo in `list_cloned`; do
 		GIT_DIR=".mgit/$repo/.git" git ls-files
 	done) | sort | uniq $1
+}
+
+which_tracks() {
+	local path="$(readlink -f $PWD0/$1)"
+	path="${path#$PWD/}" #get path relative to root for matching
+	list_tracked | grep "$path" | awk '{print $1}'
 }
 
 existing_files() {
@@ -569,6 +576,7 @@ case "$cmd" in
 	ls-modified)  list_modified ;;
 	st)           list_modified ;;
 	status)       list_modified ;;
+	which)	      which_tracks "$@" ;;
 	ls-unpushed)  list_unpushed ;;
 	ls-untracked) list_untracked ;;
 	ls-double-tracked) list_double_tracked ;;

--- a/mgit-autocomplete.sh
+++ b/mgit-autocomplete.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+__array_contains () {
+		local seeking=$1; shift
+		local in=1
+		for element; do
+				if [[ $element == $seeking ]]; then
+						in=0
+						break
+				fi
+		done
+		echo $in
+		}
+
+_mgit()
+		{
+		cur=${COMP_WORDS[COMP_CWORD]}
+		local nocomp="which remove"
+
+		if [[ $(mgit ls) != $(cd /;mgit ls) ]]
+		then
+				repos=$(mgit ls)
+		else
+				repos=()
+		fi
+
+		if [[ ${#COMP_WORDS[@]} -gt 2 ]]
+		then
+				if [[ $(__array_contains ${COMP_WORDS[1]} $nocomp) -eq 0 ]]
+				then
+						if [[ ${COMP_WORDS[1]} == "remove" ]]
+						then
+								complete="$repos"
+						else
+								return #fall back to bash file autocomplete or don't return anything
+						fi
+				elif [[ $(__array_contains ${COMP_WORDS[1]} $repos) -eq 0 ]]
+				then
+						cword=$((${#COMP_WORDS[@]}-1))
+						words=(git --git-dir=".mgit/${COMP_WORDS[1]}/.git" ${COMP_WORDS[@]:2})
+						prev=${words[$(($cword-1))]}
+						COMP_WORDS=${words[@]}
+
+						unset COMPREPLY
+						__git_main
+						unset words cword prev cur
+						return
+				else
+						complete=""
+				fi
+		else
+				local default=" init
+								remove
+								ls
+								ls-all
+								ls-uncloned
+								ls-untracked
+								ls-double-tracked
+								ls-tracked
+								which
+								ls-modified
+								status
+								ls-unpushed
+								clone
+								clone-all
+								clone-release
+								origin
+								baseurl
+								"
+
+				__gitcomp "$repos $default" #handles trailing spaces yay!
+				return
+		fi
+		COMPREPLY=( $(compgen -W "$complete" -- $cur) )
+		}
+
+complete -o bashdefault -o default -o nospace -F _mgit mgit
+


### PR DESCRIPTION
Supports completion of repo names as the second argument if inside an mgit repo otherwise suggests only the mgit commands:  
- init
- remove (followed by suggestions of repo names if applicable)
- ls
- ls-all
- ls-uncloned
- ls-untracked
- ls-double-tracked
- ls-tracked
- which (followed by standard bash file-path completion)
- ls-modified
- status
- ls-unpushed
- clone
- clone-all
- clone-release
- origin
- baseurl

After the second argument, special filename and relevant command completion is hooked directly into git's autocomplete methods and passed through.

(depends on the add-which-command PR because it adds support for falling back to filename completion and the autocompleting which; should be merged second.) 